### PR TITLE
Use permalink-style download link

### DIFF
--- a/_data/content.yml
+++ b/_data/content.yml
@@ -15,32 +15,32 @@ rss_link: http://preservethispodcast.org/podcast.rss
 episodes:
   - name: Prologue—Podcasts are Disappearing
     embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!f8e4e63fe6cd7c55e2102b378758668d8d766f58
-    download_link: https://ia801508.us.archive.org/17/items/PreserveThisPodcast-prologue-podcasts-are-disappearing/PTP_Prologue_MIX_-16LUFS_190206.mp3
+    download_link: https://archive.org/download/PreserveThisPodcast-prologue-podcasts-are-disappearing/PTP_Prologue_MIX_-16LUFS_190206.mp3
     exercises_link:
     transcript_file: transcript00-prologue
   - name: Ep1—Time to Take Notice
     embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!79bb33dadbe8c03e17a417879a02e0d005395047
-    download_link: https://ia803005.us.archive.org/28/items/PreserveThisPodcastEpisode1/PreserveThisPodcast_Episode1.mp3
+    download_link: https://archive.org/download/PreserveThisPodcastEpisode1/PreserveThisPodcast_Episode1.mp3
     exercises_link: /#zine
     transcript_file: transcript01-time-to-take-notice
   - name: Ep2—Get Organized
     embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!8656cc15c4c5d699b0d9e755db6853b3efa79ee2
-    download_link: https://ia801004.us.archive.org/25/items/PreserveThisPodcastEpisode2/PreserveThisPodcast_Episode2.mp3
+    download_link: https://archive.org/download/PreserveThisPodcastEpisode2/PreserveThisPodcast_Episode2.mp3
     exercises_link: http://preservethispodcast.org/assets/PreserveThisPodcast_Zine_Online.pdf#page=5
     transcript_file: transcript02-get-organized
   - name: Ep3—Back it up
     embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!d102a0be8c47c1fc7041b433620c3c83ab2592fe
-    download_link: https://ia801001.us.archive.org/18/items/PreserveThisPodcastEpisode3/PreserveThisPodcast_Episode3.mp3
+    download_link: https://archive.org/download/PreserveThisPodcastEpisode3/PreserveThisPodcast_Episode3.mp3
     exercises_link: http://preservethispodcast.org/assets/PreserveThisPodcast_Zine_Online.pdf#page=10
     transcript_file: transcript03-back-it-up
   - name: Ep4—Metadata Meta-awareness
     embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!b3335c5c7b8a03c28400e85d7c610d97f95aa856
-    download_link: https://ia801001.us.archive.org/22/items/PreserveThisPodcastEpisode4/PreserveThisPodcast_Episode4.mp3
+    download_link: https://archive.org/download/PreserveThisPodcastEpisode4/PreserveThisPodcast_Episode4.mp3
     exercises_link: http://preservethispodcast.org/assets/PreserveThisPodcast_Zine_Online.pdf#page=12
     transcript_file: transcript04-metadata-meta-awareness
   - name: Ep5—RSS Resuscitations
     embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!7df2c9dcfbc5eafd812949bf79e71a9ee6b44604
-    download_link: https://ia801506.us.archive.org/15/items/PreserveThisPodcastEpisode5/PreserveThisPodcast_Episode5.mp3
+    download_link: https://archive.org/download/PreserveThisPodcastEpisode5/PreserveThisPodcast_Episode5.mp3
     exercises_link:
     transcript_file: transcript05-rss-resuscitations
 

--- a/_data/content.yml
+++ b/_data/content.yml
@@ -14,32 +14,32 @@ rss_link: http://preservethispodcast.org/podcast.rss
 
 episodes:
   - name: Prologue—Podcasts are Disappearing
-    embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!f8e4e63fe6cd7c55e2102b378758668d8d766f58
+    embed_link: https://archive.org/embed/PreserveThisPodcast-prologue-podcasts-are-disappearing
     download_link: https://archive.org/download/PreserveThisPodcast-prologue-podcasts-are-disappearing/PTP_Prologue_MIX_-16LUFS_190206.mp3
     exercises_link:
     transcript_file: transcript00-prologue
   - name: Ep1—Time to Take Notice
-    embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!79bb33dadbe8c03e17a417879a02e0d005395047
+    embed_link: https://archive.org/embed/PreserveThisPodcastEpisode1
     download_link: https://archive.org/download/PreserveThisPodcastEpisode1/PreserveThisPodcast_Episode1.mp3
     exercises_link: /#zine
     transcript_file: transcript01-time-to-take-notice
   - name: Ep2—Get Organized
-    embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!8656cc15c4c5d699b0d9e755db6853b3efa79ee2
+    embed_link: https://archive.org/embed/PreserveThisPodcastEpisode2
     download_link: https://archive.org/download/PreserveThisPodcastEpisode2/PreserveThisPodcast_Episode2.mp3
     exercises_link: http://preservethispodcast.org/assets/PreserveThisPodcast_Zine_Online.pdf#page=5
     transcript_file: transcript02-get-organized
   - name: Ep3—Back it up
-    embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!d102a0be8c47c1fc7041b433620c3c83ab2592fe
+    embed_link: https://archive.org/embed/PreserveThisPodcastEpisode3
     download_link: https://archive.org/download/PreserveThisPodcastEpisode3/PreserveThisPodcast_Episode3.mp3
     exercises_link: http://preservethispodcast.org/assets/PreserveThisPodcast_Zine_Online.pdf#page=10
     transcript_file: transcript03-back-it-up
   - name: Ep4—Metadata Meta-awareness
-    embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!b3335c5c7b8a03c28400e85d7c610d97f95aa856
+    embed_link: https://archive.org/embed/PreserveThisPodcastEpisode4
     download_link: https://archive.org/download/PreserveThisPodcastEpisode4/PreserveThisPodcast_Episode4.mp3
     exercises_link: http://preservethispodcast.org/assets/PreserveThisPodcast_Zine_Online.pdf#page=12
     transcript_file: transcript04-metadata-meta-awareness
   - name: Ep5—RSS Resuscitations
-    embed_link: https://embed.radiopublic.com/e?if=preserve-this-podcast-WDJY3A&ge=s1!7df2c9dcfbc5eafd812949bf79e71a9ee6b44604
+    embed_link: https://archive.org/embed/PreserveThisPodcastEpisode5
     download_link: https://archive.org/download/PreserveThisPodcastEpisode5/PreserveThisPodcast_Episode5.mp3
     exercises_link:
     transcript_file: transcript05-rss-resuscitations

--- a/_episodes/ep0-prologue-podcasts-are-disappearing.md
+++ b/_episodes/ep0-prologue-podcasts-are-disappearing.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Prologue: Podcasts are Disappearing"
 date: 2019-02-21 09:00:00
-file: https://ia801508.us.archive.org/17/items/PreserveThisPodcast-prologue-podcasts-are-disappearing/PTP_Prologue_MIX_-16LUFS_190206.mp3
-file_itunes: https://ia801508.us.archive.org/17/items/PreserveThisPodcast-prologue-podcasts-are-disappearing/PTP_Prologue_MIX_-16LUFS_190206.mp3
+file: https://archive.org/download/PreserveThisPodcast-prologue-podcasts-are-disappearing/PTP_Prologue_MIX_-16LUFS_190206.mp3
+file_itunes: https://archive.org/download/PreserveThisPodcast-prologue-podcasts-are-disappearing/PTP_Prologue_MIX_-16LUFS_190206.mp3
 excerpt:  “The Podsucker” is a machine that Jason Scott built in his basement 15 years ago. Jason was trying to capture all the podcasts -- before they disappear. Preserve This Podcast is a series about how podcasts are disappearing. And what podcasters can do to save them. Follow along with our podcast preservation exercises by downloading the zine at preservethispodcast.org.
 summary: “The Podsucker” is a machine that Jason Scott built in his basement 15 years ago. Jason was trying to capture all the podcasts -- before they disappear. Preserve This Podcast is a series about how podcasts are disappearing. And what podcasters can do to save them. Follow along with our podcast preservation exercises by downloading the zine at preservethispodcast.org.
 duration: "04:52" #audio length in min

--- a/_episodes/ep1-time-to-take-notice.md
+++ b/_episodes/ep1-time-to-take-notice.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Episode 1: Time to Take Notice"
 date: 2019-03-21 09:00:00
-file: https://ia601301.us.archive.org/27/items/PreserveThisPodcastEpisode1/PreserveThisPodcast_Episode1.mp3
-file_itunes: https://ia601301.us.archive.org/27/items/PreserveThisPodcastEpisode1/PreserveThisPodcast_Episode1.mp3
+file: https://archive.org/download/PreserveThisPodcastEpisode1/PreserveThisPodcast_Episode1.mp3
+file_itunes: https://archive.org/download/PreserveThisPodcastEpisode1/PreserveThisPodcast_Episode1.mp3
 excerpt:  Alice Y. Hom is an oral historian who is trying to turn the interviews she’s collected into a new podcast, called Historically Queer. But even though Alice has devoted her life to preserving overlooked pieces of history, she has no idea how to preserve her podcast. Find out more, download our zine, and RSVP to our workshops at [preservethispodcast.org].
 summary: Alice Y. Hom is an oral historian who is trying to turn the interviews she’s collected into a new podcast, called Historically Queer. But even though Alice has devoted her life to preserving overlooked pieces of history, she has no idea how to preserve her podcast. Find out more, download our zine, and RSVP to our workshops at [preservethispodcast.org].
 duration: "14:19" #audio length in min

--- a/_episodes/ep2-get-organized.md
+++ b/_episodes/ep2-get-organized.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Episode 2: Get Organized"
 date: 2019-04-04 09:00:00
-file: https://ia801004.us.archive.org/25/items/PreserveThisPodcastEpisode2/PreserveThisPodcast_Episode2.mp3
-file_itunes: https://ia801004.us.archive.org/25/items/PreserveThisPodcastEpisode2/PreserveThisPodcast_Episode2.mp3
+file: https://archive.org/download/PreserveThisPodcastEpisode2/PreserveThisPodcast_Episode2.mp3
+file_itunes: https://archive.org/download/PreserveThisPodcastEpisode2/PreserveThisPodcast_Episode2.mp3
 excerpt: The first step in preserving a podcast is to get organized! For this episode we work with Dan Weissman, the producer of a podcast called An Arm and a Leg, on organizing his files. We cover folder structures, file naming conventions, and the challenges of navigating digital oceans of stuff. Find out more, download our zine, and RSVP to our traveling workshops at [preservethispodcast.org].
 summary: The first step in preserving a podcast is to get organized! For this episode we work with Dan Weissman, the producer of a podcast called An Arm and a Leg, on organizing his files. We cover folder structures, file naming conventions, and the challenges of navigating digital oceans of stuff. Find out more, download our zine, and RSVP to our traveling workshops at [preservethispodcast.org].
 duration: "16:29" #audio length in min

--- a/_episodes/ep3-back-it-up.md
+++ b/_episodes/ep3-back-it-up.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Episode 3: Back it up"
 date: 2019-04-18 09:00:00
-file: https://ia801001.us.archive.org/18/items/PreserveThisPodcastEpisode3/PreserveThisPodcast_Episode3.mp3
-file_itunes: https://ia801001.us.archive.org/18/items/PreserveThisPodcastEpisode3/PreserveThisPodcast_Episode3.mp3
+file: https://archive.org/download/PreserveThisPodcastEpisode3/PreserveThisPodcast_Episode3.mp3
+file_itunes: https://archive.org/download/PreserveThisPodcastEpisode3/PreserveThisPodcast_Episode3.mp3
 excerpt: Get ready for the digital storage showdown! Nearly everyone has a hard drive horror story. If you listen to this podcast, you won’t be one of them. In this episode we work with Amanda McLoughlin and Eric Silver, two indie podcasters working with the Multitude production collective. We go over the best techniques for backing up files, from hard drives to RAIDs to cloud storage. Find out more, download our zine (p.10), and RSVP to our traveling workshops at [preservethispodcast.org].
 summary: Get ready for the digital storage showdown! Nearly everyone has a hard drive horror story. If you listen to this podcast, you won’t be one of them. In this episode we work with Amanda McLoughlin and Eric Silver, two indie podcasters working with the Multitude production collective. We go over the best techniques for backing up files, from hard drives to RAIDs to cloud storage. Find out more, download our zine (p.10), and RSVP to our traveling workshops at [preservethispodcast.org].
 duration: "14:19" #audio length in min

--- a/_episodes/ep4-metadata-meta-awareness.md
+++ b/_episodes/ep4-metadata-meta-awareness.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Ep4: Metadata Meta-awareness"
 date: 2019-05-02 09:00:00
-file: https://ia801001.us.archive.org/22/items/PreserveThisPodcastEpisode4/PreserveThisPodcast_Episode4.mp3
-file_itunes: https://ia801001.us.archive.org/22/items/PreserveThisPodcastEpisode4/PreserveThisPodcast_Episode4.mp3
+file: https://archive.org/download/PreserveThisPodcastEpisode4/PreserveThisPodcast_Episode4.mp3
+file_itunes: https://archive.org/download/PreserveThisPodcastEpisode4/PreserveThisPodcast_Episode4.mp3
 excerpt: Metadata makes podcast files accessible. Follow Kaytlin Bailey, host of the Oldest Profession podcast, as she tries to make little-known histories of sex work accessible, now and in the future. We will cover MP3 ID3 tags, episode descriptions, transcripts, and how machine learning will affect podcast discovery. Featuring host and producer Molly Schwartz, and archivists Dana Gerber-Margie and Mary Kidd. Find out more, download our zine (p.12), and RSVP to our traveling workshops at [preservethispodcast.org].
 summary: Metadata makes podcast files accessible. Follow Kaytlin Bailey, host of the Oldest Profession podcast, as she tries to make little-known histories of sex work accessible, now and in the future. We will cover MP3 ID3 tags, episode descriptions, transcripts, and how machine learning will affect podcast discovery. Featuring host and producer Molly Schwartz, and archivists Dana Gerber-Margie and Mary Kidd. Find out more, download our zine (p.12), and RSVP to our traveling workshops at [preservethispodcast.org].
 duration: "26:30" #audio length in min

--- a/_episodes/ep5-rss-resuscitations.md
+++ b/_episodes/ep5-rss-resuscitations.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Episode 5: RSS Resuscitations"
 date: 2019-05-16 09:00:00
-file: https://ia801506.us.archive.org/15/items/PreserveThisPodcastEpisode5/PreserveThisPodcast_Episode5.mp3
-file_itunes: https://ia801506.us.archive.org/15/items/PreserveThisPodcastEpisode5/PreserveThisPodcast_Episode5.mp3
+file: https://archive.org/download/PreserveThisPodcastEpisode5/PreserveThisPodcast_Episode5.mp3
+file_itunes: https://archive.org/download/PreserveThisPodcastEpisode5/PreserveThisPodcast_Episode5.mp3
 excerpt: Podcasts rely on RSS feeds for distribution. But what happens when podcasters stop paying for RSS hosting? How can we keep podcasts accessible? In this episode, Molly Schwartz and Sarah Nguyen explore options for free self-hosting for the Preserve This Podcast podcast. Featuring Dave Winer, Jason Scott, Elsie Escobar, and Brad Smith. Find out more, download our zine, and RSVP to our traveling workshops at [preservethispodcast.org].
 summary: Podcasts rely on RSS feeds for distribution. But what happens when podcasters stop paying for RSS hosting? How can we keep podcasts accessible? In this episode, Molly Schwartz and Sarah Nguyen explore options for free self-hosting for the Preserve This Podcast podcast. Featuring Dave Winer, Jason Scott, Elsie Escobar, and Brad Smith. Find out more, download our zine, and RSVP to our traveling workshops at [preservethispodcast.org].
 duration: "20:11" #audio length in min


### PR DESCRIPTION
According to https://archive.org/help/audio.php

Temporary links in the form of `https://{server}.{loc}.archive.org/{}/items/` should not be used for long-term purposes.

---

Also fixed the embed player.